### PR TITLE
Rename some command line options to more sensible names

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Features currently supported:
 
 - Profile cmsRun jobs with valgrind or callgrind
 
-- Just run with whatever is in your config (e.g. to stop hogging resources on `soolin`)
+- Just run with whatever is in your config (`--asIs`) e.g. to stop hogging resources on `soolin`
 
 - hadd the output from jobs (need to specify which module's output you want to hadd)
 

--- a/cmsRunCondor/cmsRunCondor.py
+++ b/cmsRunCondor/cmsRunCondor.py
@@ -59,9 +59,9 @@ class ArgParser(argparse.ArgumentParser):
                                    help="Pass in a list of filenames to run over. "
                                    "This will ignore --dataset/--secondaryDataset/"
                                    "--lumiMask/--runRange options.")
-        input_sources.add_argument("--useConfig",
-                                   help="Use the input files and number of events "
-                                   "specified in the config file."
+        input_sources.add_argument("--asIs",
+                                   help="Use the exact input files and number of events "
+                                   "specified in the config file (i.e. \"as-is\"). "
                                    "This will ignore --dataset, totalUnits, unitsPerJob, etc",
                                    action='store_true')
 
@@ -145,7 +145,7 @@ class ArgParser(argparse.ArgumentParser):
         other_group = self.add_argument_group("MISC\n"+'-'*bar_length)
 
         other_group.add_argument("--verbose", "-v",
-                                 help="Extra printout to clog up your screen.",
+                                 help="Extra printout to help debug problems.",
                                  action='store_true')
         other_group.add_argument("--dry",
                                  help="Dry-run: only make condor submission script, "
@@ -206,7 +206,7 @@ def check_args(args):
     flag_mutually_exclusive_args(args, ['filelist'], ['splitByLumis', 'lumiMask', 'runRange'])
 
     flag_mutually_exclusive_args(args,
-                                 ['useConfig', 'valgrind', 'callgrind'],
+                                 ['asIs', 'valgrind', 'callgrind'],
                                  ['splitByFiles', 'splitByLumis', 'lumiMask', 'runRange',
                                   'unitsPerJob', 'totalUnits', 'secondaryDataset'])
 
@@ -771,7 +771,7 @@ def cmsRunCondor(in_args=sys.argv[1:]):
 
     # This could probably be done better!
 
-    if not args.valgrind and not args.callgrind and not args.useConfig:
+    if not args.valgrind and not args.callgrind and not args.asIs:
         list_of_files, list_of_secondary_files = None, None
         list_of_lumis = None
 
@@ -873,7 +873,7 @@ def cmsRunCondor(in_args=sys.argv[1:]):
             job_name = "callgrind"
         elif args.valgrind:
             job_name = "valgrind"
-        elif args.useConfig:
+        elif args.asIs:
             job_name = "cmsRun_%s" % strftime("%H%M%S")
         else:
             job_name = args.dataset[1:].replace("/", "_").replace("-", "_")
@@ -918,7 +918,7 @@ def cmsRunCondor(in_args=sys.argv[1:]):
                 args_str += ' -l ' + os.path.basename(lumilist_filename)
             elif is_url(args.lumiMask):
                 args_str += ' -l ' + args.lumiMask
-        if args.useConfig:
+        if args.asIs:
             args_str += ' -u'
         if args.valgrind:
             args_str += ' -m'

--- a/cmsRunCondor/cmsRunCondor.py
+++ b/cmsRunCondor/cmsRunCondor.py
@@ -126,8 +126,8 @@ class ArgParser(argparse.ArgumentParser):
                                   help="Where you want your output to be stored. "
                                   "Must be on /hdfs.",
                                   required=True)
-        output_group.add_argument("--outputScript",
-                                  help="Name of condor submission script. "
+        output_group.add_argument("--condorScript",
+                                  help="Specify condor submission script filename. "
                                   "Should be on /storage or /scratch",
                                   default=generate_script_filename(USER_DICT))
         output_group.add_argument("--dag",
@@ -210,7 +210,7 @@ def check_args(args):
                                  ['splitByFiles', 'splitByLumis', 'lumiMask', 'runRange',
                                   'unitsPerJob', 'totalUnits', 'secondaryDataset'])
 
-    args.outputScript = os.path.abspath(args.outputScript)
+    args.condorScript = os.path.abspath(args.condorScript)
 
     if args.filelist:
         args.filelist = os.path.abspath(args.filelist)
@@ -230,7 +230,7 @@ def check_args(args):
         flag_dependent_args(args, ['dataset'], ['secondaryDataset'])
         log.info("Running 2-file solution with secondary dataset %s", args.secondaryDataset)
 
-    args.outputScript = os.path.abspath(args.outputScript)
+    args.condorScript = os.path.abspath(args.condorScript)
     args.logDir = os.path.abspath(args.logDir)
 
     if args.dag:
@@ -239,12 +239,12 @@ def check_args(args):
     if args.lumiMask and not is_url(args.lumiMask):
         args.lumiMask = os.path.abspath(args.lumiMask)
 
-    for f in [args.outputScript, args.dag, args.logDir]:
+    for f in [args.condorScript, args.dag, args.logDir]:
         if f:
             if os.path.abspath(f).startswith("/hdfs") or os.path.abspath(f).startswith("/users"):
                 raise IOError("You cannot put %s on /users or /hdfs" % f)
 
-    if '--outputScript' not in sys.argv:
+    if '--condorScript' not in sys.argv:
         log.warning("You didn't specify a condor script, auto-generated one at %s", generate_script_filename(USER_DICT))
 
     if '--log' not in sys.argv:
@@ -882,7 +882,7 @@ def cmsRunCondor(in_args=sys.argv[1:]):
     cmsrun_jobs = ht.JobSet(
         exe=os.path.join(script_dir, 'cmsRun_worker.sh'),
         copy_exe=True,
-        filename=args.outputScript,
+        filename=args.condorScript,
         out_dir=args.logDir, out_file='cmsRun.$(cluster).$(process).out',
         err_dir=args.logDir, err_file='cmsRun.$(cluster).$(process).err',
         log_dir=args.logDir, log_file='cmsRun.$(cluster).$(process).log',

--- a/cmsRunCondor/cmsRunCondor.py
+++ b/cmsRunCondor/cmsRunCondor.py
@@ -123,8 +123,8 @@ class ArgParser(argparse.ArgumentParser):
                                                "Options for outputs")
 
         output_group.add_argument("--outputDir",
-                                  help="Where you want your output to be stored. "
-                                  "Must be on /hdfs.",
+                                  help="Where you want your cmsRun ROOT output files "
+                                  " to be stored. Must be on /hdfs.",
                                   required=True)
         output_group.add_argument("--condorScript",
                                   help="Specify condor submission script filename. "
@@ -134,7 +134,7 @@ class ArgParser(argparse.ArgumentParser):
                                   help="Specify DAG filename if you want to run as a condor DAG. "
                                   "Should be on /storage or /scratch. "
                                   "Will auto-generate DAG filename "
-                                  "if no argument specified (%s)" % generate_dag_filename(USER_DICT),
+                                  "if no argument specified (default: %s)" % generate_dag_filename(USER_DICT),
                                   nargs='?',
                                   const=generate_dag_filename(USER_DICT))
         output_group.add_argument('--logDir',

--- a/cmsRunCondor/cmsRunCondor.py
+++ b/cmsRunCondor/cmsRunCondor.py
@@ -137,8 +137,8 @@ class ArgParser(argparse.ArgumentParser):
                                   "if no argument specified (%s)" % generate_dag_filename(USER_DICT),
                                   nargs='?',
                                   const=generate_dag_filename(USER_DICT))
-        output_group.add_argument('--log',
-                                  help="Location to store job stdout/err/log files. "
+        output_group.add_argument('--logDir',
+                                  help="Directory to store job stdout/err/log files. "
                                   "Should be on /storage or /scratch",
                                   default=generate_log_dir(USER_DICT))
 
@@ -231,7 +231,7 @@ def check_args(args):
         log.info("Running 2-file solution with secondary dataset %s", args.secondaryDataset)
 
     args.outputScript = os.path.abspath(args.outputScript)
-    args.log = os.path.abspath(args.log)
+    args.logDir = os.path.abspath(args.logDir)
 
     if args.dag:
         args.dag = os.path.abspath(args.dag)
@@ -239,7 +239,7 @@ def check_args(args):
     if args.lumiMask and not is_url(args.lumiMask):
         args.lumiMask = os.path.abspath(args.lumiMask)
 
-    for f in [args.outputScript, args.dag, args.log]:
+    for f in [args.outputScript, args.dag, args.logDir]:
         if f:
             if os.path.abspath(f).startswith("/hdfs") or os.path.abspath(f).startswith("/users"):
                 raise IOError("You cannot put %s on /users or /hdfs" % f)
@@ -883,9 +883,9 @@ def cmsRunCondor(in_args=sys.argv[1:]):
         exe=os.path.join(script_dir, 'cmsRun_worker.sh'),
         copy_exe=True,
         filename=args.outputScript,
-        out_dir=args.log, out_file='cmsRun.$(cluster).$(process).out',
-        err_dir=args.log, err_file='cmsRun.$(cluster).$(process).err',
-        log_dir=args.log, log_file='cmsRun.$(cluster).$(process).log',
+        out_dir=args.logDir, out_file='cmsRun.$(cluster).$(process).out',
+        err_dir=args.logDir, err_file='cmsRun.$(cluster).$(process).err',
+        log_dir=args.logDir, log_file='cmsRun.$(cluster).$(process).log',
         cpus=1, memory='2GB', disk='3GB',
         # cpus=1, memory='1GB', disk='500MB',
         certificate=True,

--- a/cmsRunCondor/cmsRunCondor.py
+++ b/cmsRunCondor/cmsRunCondor.py
@@ -217,6 +217,15 @@ def check_args(args):
         if not os.path.isfile(args.filelist):
             raise IOError("Cannot find filelist %s" % args.filelist)
 
+        if not args.splitByFiles:
+            log.warning("You didn't specify --splitByFiles, but since you're using "
+                        "--filelist I'm going to split jobs by number of files anyway")
+        args.splitByFiles = True
+
+    elif args.dataset:
+      if not args.splitByFiles and not args.splitByLumis:
+          raise RuntimeError("If using --dataset, need either --splitByFiles or --splitByLumis")
+
     # for now, restrict output dir to /hdfs
     if not args.outputDir.startswith('/hdfs'):
         raise RuntimeError('Output directory (--outputDir) not on /hdfs')

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,22 @@ from distutils.core import setup
 
 setup(
     name='condor-comforter',
-    version='0.1',
+    version='0.2',
     description="Some helper scripts for running HTCondor jobs",
     author='Robin Aggleton',
     author_email='',
     url='https://github.com/BristolComputing/condor-comforter',
-    py_modules=['cmsRunCondor.cmsRunCondor', 'haddaway.haddaway'],
+    packages=['cmsRunCondor', 'haddaway'],
     scripts=['cmsRunCondor/cmsRunCondor.py', 'haddaway/haddaway.py'],
     install_requires=['htcondenser>=0.3.0'],
     dependency_links=['git+https://github.com/raggleton/htcondenser#egg=htcondenser-0.3.0'],
+    # need this for the script version
     data_files=[
         ('bin', ['cmsRunCondor/cmsRun_worker.sh'])
-    ]
+    ],
+    # need these 2 for the package version
+    include_package_data=True,
+    package_data={
+        'cmsRunCondor': ['cmsRun_worker.sh']
+    }
 )


### PR DESCRIPTION
Users have pointed out that some of the command line options are badly named ( #5, #7)  . This attempts to fix this.

`--useConfig` --> `--asIs`  (confusing as it implies you should pass the cmssw config name)
`--log` --> `--logDir`  (not consistent with `outputDir`)
`--outputScript` --> `--condorScript` (confusing as a condor thing, not an actual important output file for the user)

It also fixes #6  (yes I should have put it in a separate PR, but thought I'd do all the command line args fixes in one PR)

It also updates the version number.

This should be merged after #10.
 